### PR TITLE
fixed getting more messages based on offset value

### DIFF
--- a/src/apis/message/message.controller.js
+++ b/src/apis/message/message.controller.js
@@ -177,8 +177,12 @@ router.get('/messages/:id', (req, res) => {
  * get 100 messages on click of any group
  */
 router.get('/messages/users/:userId/groups/:groupId', (req, res) => {
-    messageService.getLimitedMessages((req.params.groupId), (req.params.userId), (req.query.offset), (req.query.size), (result) => {
-        res.send(result);
+    messageService.getLimitedMessages((req.params.groupId), (req.params.userId), (req.query.page), (req.query.size), (err, results) => {
+        if (err) {
+            log.error('err', err);
+            res.status(400).send(err);
+        }
+        res.send(results);
     });
 });
 

--- a/src/apis/message/message.service.js
+++ b/src/apis/message/message.service.js
@@ -71,13 +71,14 @@ class MessageService {
     }
 
     /**
-     * render 100 message onclick of any group
+     * render 20 message onclick of any group
      */
-    getLimitedMessages(receiverId, senderId, offset, size, callback) {
-        Message.find({ receiverId: receiverId }, (err, messages) => {
-            if (err) throw err;
-            callback(messages);
-        }).limit(parseInt(offset + size)).skip(parseInt(offset)).sort({ $natural: -1 });
+    getLimitedMessages(receiverId, senderId, page, size, callback) {
+        Message.find({ receiverId: receiverId })
+            .skip(parseInt(((size * page) - size)))
+            .limit(parseInt(size))
+            .sort({ $natural: -1 })
+            .exec(callback);
     }
 }
 


### PR DESCRIPTION
- The method used to return all the messages on calling. Have renamed `offset` to `page`. Hence the count goes from page 1 to end of the page.